### PR TITLE
restart after shortcut modification.

### DIFF
--- a/docs/02-installation.md
+++ b/docs/02-installation.md
@@ -235,7 +235,7 @@ Browse to this folder and edit the properties of the Duplicati 2 shortcut. Add  
 
 ![](ss_conftrayicon_01.png)
 
-A Duplicati icon will be shown in the system tray after logging in to Windows, but the Duplicati server component needs to be started separately.
+Because at the moment the internal server component of the Tray Icon tool is already running you need to restart your PC for changes to take effect. After PC restart a Duplicati icon will be shown in the system tray after logging in to Windows, but the Duplicati server component needs to be started separately.
 
 *****
 > ![](icon_info.png) If you disabled Launch Duplicati at startup in the installation wizard and want to startup the Duplicati Server component during bootup time, you have to register Duplicati Server as a Windows service. See [Duplicati.WindowsService.exe](07-other-command-line-utilities/#duplicati-windowsservice-exe) for more information.


### PR DESCRIPTION
From: https://duplicati.readthedocs.io/en/latest/02-installation/#installing-duplicati-on-windows

*This will ease access to the Duplicati Web interface, but if you don't manually deactivate the internal server component, you will end up with multiple Duplicati instances, which is probably undesirable.*

In that case, when the shortcut is modified tray server is already launched, so pc needs restart for changes to take effect and only after that user can launch server as service to avoid tray server and server as service running together.