### PR TITLE
Update 06-advanced-options.md

### DIFF
--- a/docs/06-advanced-options.md
+++ b/docs/06-advanced-options.md
@@ -490,7 +490,7 @@ Default value: `false`
 ### accept-specified-ssl-hash
 `--accept-specified-ssl-hash (String)`  
 Optionally accept a known SSL certificate.  
-If your server certificate is reported as invalid (eg. with self-signed certificates), you can supply the certificate hash to approve it anyway. The hash value must be entered in hex format without spaces. You can enter multiple hashes separated by commas.
+If your server certificate is reported as invalid (eg. with self-signed certificates), you can supply the certificate hash (SHA256) to approve it anyway. The hash value must be entered in hex format without spaces or colons. You can enter multiple hashes separated by commas.
 
 ### accept-any-ssl-certificate
 `--accept-any-ssl-certificate (Boolean)`  


### PR DESCRIPTION
When viewing a hex-hash of a certificate, it is usually displayed with colons - it should be stated that these must be removed for duplicati to recognize the hash. Furthermore, a specification of the hashes accepted (SHA256, SHA1, MD5...) should be added.