### PR TITLE
Update 04-using-duplicati-from-the-command-line.md

### DIFF
--- a/docs/04-using-duplicati-from-the-command-line.md
+++ b/docs/04-using-duplicati-from-the-command-line.md
@@ -217,6 +217,9 @@ Tries to repair the backup. If no local database is found or the database is emp
 
 `Duplicati.CommandLine.exe repair <storage-URL> [<options>]`
 
+Example for B2 storage:
+`Duplicati.CommandLine.exe repair "b2://blacksmith/photos?auth-username=1234567890&auth-password=123ABc456dEfGH" --dbpath="C:\Users\User1\AppData\Local\Duplicati\SONSONSHE.sqlite" --passphrase="1234567890ABCdef"`
+
 ## The AFFECTED command
 
 Returns a report explaining what backup sets and files are affected by a remote file. You can use this option to see what source files are affected if one or more remote files are damaged or deleted. The advanced option `dbpath` is required to specify the location of the local database. Usage:


### PR DESCRIPTION
I think Repair is one of the most used commands, so any example will be of help. What we have right now didn't help me when I tried to run repair from CLI for the first time. My questions were like "what should Storage URL look like?" and "what options are there? are they really optional or mandatory?" Those may sound stupid for advanced users, but it's the beginners who read the manual right? ;-)