### PR TITLE
Fix documentation of --gcs-storage-class options

### DIFF
--- a/docs/05-storage-providers.md
+++ b/docs/05-storage-providers.md
@@ -426,16 +426,9 @@ Specifies storage class for creating a bucket.
 This option is only used when creating new buckets. Use this option to change what storage type the bucket has.
 Charges and functionality vary with bucket storage class. Known storage classes:
     * (default):
-    * Europe: EU
-    * United States: US
-    * Asia: ASIA
-    * Eastern Asia-Pacific: ASIA-EAST1
-    * Central United States 1: US-CENTRAL1
-    * Central United States 2: US-CENTRAL2
-    * Eastern United States 1: US-EAST1
-    * Eastern United States 2: US-EAST2
-    * Eastern United States 3: US-EAST3
-    * Western United States: US-WEST1
+    * Standard: STANDARD
+    * Durable Reduced Availability (DRA): DURABLE_REDUCED_AVAILABILITY
+    * Nearline: NEARLINE
 * `--authid (Password)`
 The authorization code.
 The authorization token retrieved from https://duplicati-oauth-handler.appspot.com?type=gcs


### PR DESCRIPTION
The documentation for the --gcs-storage-class options was just a copy of the --gcs-location options. Put the actual values from the code, which is here: https://github.com/duplicati/duplicati/blob/b41d3a3cff8fb868988845f81502ac543d80e57c/Duplicati/Library/Backend/GoogleServices/WebApi.cs