### PR TITLE
Fix documentation for ConfigurationImporter utility

### DIFF
--- a/docs/07-other-command-line-utilities.md
+++ b/docs/07-other-command-line-utilities.md
@@ -302,7 +302,7 @@ This adds the ability to import backup configurations from the command-line. Thi
 
 The usage is as follows:
 ```
-ConfigurationImporter.exe <configuration-file> --import-metadata=(true | false) --server-datafolder=<path to .sqlite file> [<advanced-option>]...
+ConfigurationImporter.exe <configuration-file> --import-metadata=(true | false) --server-datafolder=<path to .sqlite file>
 ```
 For example:
 ```


### PR DESCRIPTION
The ability to specify advanced options from the command line were removed in https://github.com/duplicati/duplicati/pull/3622. This avoids having to resolve ambiguities between options provided from the command line and those contained in the JSON configuration file.