### PR TITLE
Update 03-using-the-graphical-user-interface.md

### DIFF
--- a/docs/03-using-the-graphical-user-interface.md
+++ b/docs/03-using-the-graphical-user-interface.md
@@ -697,7 +697,7 @@ The creation of the bug report starts immediately.
 
 When completed, a message is displayed and you can download the generated report.
 
-![](ss_createbugreport_02.png)
+![](ss_createbugreport_03.png)
 
 Click the Download button and send the report to the Duplicati development team for further investigation.
 


### PR DESCRIPTION
The documentation for the section "Creating a bug report" uses the same image twice in a row. The link for the second image has been corrected.