### PR TITLE
Warns that before scripts can set env vars

### DIFF
--- a/docs/06-advanced-options.md
+++ b/docs/06-advanced-options.md
@@ -552,6 +552,7 @@ Default value: `false`
 ## Scripting options
 
 With these options you can executes a script before starting an operation, and again on completion. Module is loaded automatically, use `--disable-module` to prevent this.
+**Warning** 'before' scripts can set environment variable(s) by writing to stdout. See run-script-exemple for more information.
 
 ### run-script-before
 `--run-script-before (Path)`  


### PR DESCRIPTION
This can trip people as seen in this forum post: https://forum.duplicati.com/t/duplicati-library-main-controller-unsupportedoption/13104/15