### PR TITLE
Fix unclosed quotes in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,4 +84,4 @@ pages:
         - "Filters": "appendix-d-filters.md"
         - "How We Get Along With OAuth": "appendix-e-how-we-get-along-with-oauth.md"
         - "Example Scripts": "appendix-g-example-scripts.md"
-        - "License Agreement: "appendix-f-license-agreement.md"
+        - "License Agreement": "appendix-f-license-agreement.md"


### PR DESCRIPTION
Unclosed quotes in mkdocs.yml cause build error (MkDocs encountered an error parsing the configuration file)