### PR TITLE
Fix conflicting dependencies in pip-requirements.txt

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,3 +1,4 @@
 pygments>=2.4
 pymdown-extensions
+markdown>=3.2.1,<3.4
 mkdocs-material


### PR DESCRIPTION
Latest mkdocs 1.4.1 requires markdown<3.4,>=3.2.1, if this is not explicitly specified, it will be installed markdown 3.4.1