### PR TITLE
Nudge user to use PEM format for SSH keys

### DIFF
--- a/docs/05-storage-providers.md
+++ b/docs/05-storage-providers.md
@@ -263,6 +263,7 @@ To guard against man-in-the-middle attacks, the server fingerprint is verified o
 * `--ssh-keyfile`
 Points to a valid OpenSSH keyfile. If the file is encrypted, the password supplied is used to decrypt the keyfile.
 If this option is supplied, the password is not used to authenticate. This option only works when using the managed SSH client.
+This key should be in PEM format, e.g. created with `ssh-keygen -m pem`.
 * `--ssh-key`
 An url-encoded SSH private key. The private key must be prefixed with `sshkey://`. If the file is encrypted, the password supplied is used to decrypt the keyfile. If this option is supplied, the password is not used to authenticate. This option only works when using the managed SSH client.
 * `--ssh-operation-timeout = 0`

--- a/docs/05-storage-providers.md
+++ b/docs/05-storage-providers.md
@@ -263,7 +263,8 @@ To guard against man-in-the-middle attacks, the server fingerprint is verified o
 * `--ssh-keyfile`
 Points to a valid OpenSSH keyfile. If the file is encrypted, the password supplied is used to decrypt the keyfile.
 If this option is supplied, the password is not used to authenticate. This option only works when using the managed SSH client.
-This key should be in PEM format, e.g. created with `ssh-keygen -m pem`.
+This key may need to be in PEM format, e.g. created with `ssh-keygen -m pem`, if Duplicati reports an error like _openssh key type: ssh-rsa is not supported_.
+
 * `--ssh-key`
 An url-encoded SSH private key. The private key must be prefixed with `sshkey://`. If the file is encrypted, the password supplied is used to decrypt the keyfile. If this option is supplied, the password is not used to authenticate. This option only works when using the managed SSH client.
 * `--ssh-operation-timeout = 0`


### PR DESCRIPTION
See also:

https://github.com/duplicati/duplicati/issues/3360

https://forum.duplicati.com/t/openssh-rsa-keys-not-supported/12619/8

Duplicati uses SSH.NET. https://github.com/sshnet/SSH.NET/issues/485 describes the need for PEM format.