### PR TITLE
Add a comment, not to use modern encryption for PKCS#12

### DIFF
--- a/docs/07-other-command-line-utilities.md
+++ b/docs/07-other-command-line-utilities.md
@@ -69,7 +69,7 @@ The path to the folder where the static files for the webserver is present. The 
 * `--webservice-port`  
 The port the webserver listens on. Multiple values may be supplied with a comma in between.
 * `--webservice-sslcertificatefile`  
-The certificate and key file in PKCS #12 format the webserver use for SSL. Only RSA/DSA keys are supported.
+The certificate and key file in PKCS #12 format the webserver use for SSL. Only RSA/DSA keys are supported. Also, under mono, the modern (i.e. AES) encryptions for the PKCS#12 files are not supported (PBE-SHA1-3DES is one example that works).
 * `--webservice-sslcertificatepassword`  
 The password for decryption of certificate PKCS #12 file.
 * `--webservice-interface`  


### PR DESCRIPTION
While modern encryption algorithms (e.g. `AES-256-CBC`) work fine on Windows when importing a PKCS#12 file, they do not work on mono. Viable algorithms seem not to be publicly documented, but are only available [in source](https://github.com/mono/mono/blob/c6cdaadb54a1173484f1ada524306ddbf8c2e7d5/mcs/class/Mono.Security/Mono.Security.X509/PKCS12.cs#L589-L657).

Thus, I added only a vague hint not to use a modern algorithm, but rather an old one. `PBE-SHA1-3DES` is the one that worked fine in my tests.

To "convert" between the encryption formats I used the following method:

```sh
openssl pkcs12 -in modern-enc-file.p12 -out tmp.cer -nokeys
openssl pkcs12 -in modern-enc-file.p12 -out tmp.key -nocerts
openssl pkcs12 -export -in tmp.cer -inkey tmp.key -out pbe-enc-file.p12 -certpbe PBE-SHA1-3DES
rm tmp.cer tmp.key
```

